### PR TITLE
Change monetary attributes from String to BigDecimal

### DIFF
--- a/src/main/java/uk/gov/digital/ho/proving/financial/model/CappedValues.java
+++ b/src/main/java/uk/gov/digital/ho/proving/financial/model/CappedValues.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.math.BigDecimal;
 import java.util.Objects;
 
 /**
@@ -12,17 +13,17 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class CappedValues {
 
-    private final String accommodationFeesPaid;
+    private final BigDecimal accommodationFeesPaid;
     private final int courseLength;
 
     @JsonCreator
-    public CappedValues(@JsonProperty("accommodationFeesPaid") String accommodationFeesPaid,
+    public CappedValues(@JsonProperty("accommodationFeesPaid") BigDecimal accommodationFeesPaid,
                         @JsonProperty("courseLength") int courseLength) {
         this.accommodationFeesPaid = accommodationFeesPaid;
         this.courseLength = courseLength;
     }
 
-    public String getAccommodationFeesPaid() {
+    public BigDecimal getAccommodationFeesPaid() {
         return accommodationFeesPaid;
     }
 
@@ -47,7 +48,7 @@ public final class CappedValues {
     @Override
     public String toString() {
         return "CappedValues{" +
-            "accommodationFeesPaid='" + accommodationFeesPaid + '\'' +
+            "accommodationFeesPaid=" + accommodationFeesPaid +
             ", courseLength=" + courseLength +
             '}';
     }

--- a/src/test/groovy/uk/gov/digital/ho/proving/financial/ServiceSpec.groovy
+++ b/src/test/groovy/uk/gov/digital/ho/proving/financial/ServiceSpec.groovy
@@ -97,7 +97,7 @@ class ServiceSpec extends Specification {
     }
 
     ResponseDetails details = new ResponseDetails("200", "OK")
-    CappedValues cappedValues= new CappedValues("100", 9)
+    CappedValues cappedValues= new CappedValues(100, 9)
 
     String thresholdResponseJson = mapper.writeValueAsString(new ThresholdResult(1, cappedValues, details))
     String passResponseJson = mapper.writeValueAsString(new DailyBalanceStatusResult(true, null, details))

--- a/src/test/groovy/uk/gov/digital/ho/proving/financial/api/FundingCheckResponseSpec.groovy
+++ b/src/test/groovy/uk/gov/digital/ho/proving/financial/api/FundingCheckResponseSpec.groovy
@@ -96,7 +96,7 @@ class FundingCheckResponseSpec extends Specification {
         LocalDate.of(2015, 10, 3),
         BigDecimal.valueOf(100),
         lowBalanceFailure,
-        new CappedValues("1265.00", 9)
+        new CappedValues(1265.00, 9)
     )
 
     def static sampleThree = new FundingCheckResponse(
@@ -104,7 +104,7 @@ class FundingCheckResponseSpec extends Specification {
         LocalDate.of(2015, 10, 3),
         BigDecimal.valueOf(100),
         recordCountFailure,
-        new CappedValues("1265.00", 9)
+        new CappedValues(1265.00, 9)
     )
 
     def stringFromFile(String fileName) {

--- a/src/test/groovy/uk/gov/digital/ho/proving/financial/integration/FinancialStatusCheckerSpec.groovy
+++ b/src/test/groovy/uk/gov/digital/ho/proving/financial/integration/FinancialStatusCheckerSpec.groovy
@@ -49,7 +49,7 @@ class FinancialStatusCheckerSpec extends Specification {
 
     def thresholdOf(BigDecimal minimum) {
         def threshold = BigDecimal.valueOf(minimum)
-        def thresholdResult = new ThresholdResult(threshold, new CappedValues("100", 9), new ResponseDetails("200", "OK"))
+        def thresholdResult = new ThresholdResult(threshold, new CappedValues(100, 9), new ResponseDetails("200", "OK"))
         thresholdResponse = new ResponseEntity(thresholdResult, OK);
     }
 

--- a/src/test/groovy/uk/gov/digital/ho/proving/financial/integration/ThresholdResultSpec.groovy
+++ b/src/test/groovy/uk/gov/digital/ho/proving/financial/integration/ThresholdResultSpec.groovy
@@ -71,7 +71,7 @@ class ThresholdResultSpec extends Specification {
 
     def sampleOne = new ThresholdResult(
         BigDecimal.valueOf(100),
-        new CappedValues("1265.00", 9),
+        new CappedValues(1265.00, 9),
         new ResponseDetails("200", "OK"))
 
     def stringFromFile(String fileName) {

--- a/src/test/groovy/uk/gov/digital/ho/proving/financial/model/CappedValuesSpec.groovy
+++ b/src/test/groovy/uk/gov/digital/ho/proving/financial/model/CappedValuesSpec.groovy
@@ -11,7 +11,7 @@ class CappedValuesSpec extends Specification {
     def "generates meaningful toString instead of just a hash"() {
 
         given:
-        def instance = new CappedValues("200", 9)
+        def instance = new CappedValues(200.00, 9)
 
         when:
         def output = instance.toString()

--- a/src/test/resources/fundingcheckresponse-sample-three.json
+++ b/src/test/resources/fundingcheckresponse-sample-three.json
@@ -6,7 +6,7 @@
         "recordCount" : 27
     },
     "cappedValues" : {
-        "accommodationFeesPaid": "1265.00",
+        "accommodationFeesPaid": 1265.00,
         "courseLength": 9
     }
 }

--- a/src/test/resources/fundingcheckresponse-sample-two.json
+++ b/src/test/resources/fundingcheckresponse-sample-two.json
@@ -7,7 +7,7 @@
         "lowestBalanceValue": 100
     },
     "cappedValues" : {
-        "accommodationFeesPaid": "1265.00",
+        "accommodationFeesPaid": 1265.00,
         "courseLength": 9
     }
 }

--- a/src/test/resources/thresholdresult-sample-one.json
+++ b/src/test/resources/thresholdresult-sample-one.json
@@ -1,7 +1,7 @@
 {
     "threshold": 100,
     "cappedValues" : {
-        "accommodationFeesPaid": "1265.00",
+        "accommodationFeesPaid": 1265.00,
         "courseLength": 9
     },
     "status": {


### PR DESCRIPTION
Changes CappedValues.accommodationFeesPaid from a String to a Decimal.

You'll probably need this when Andy changes the API
